### PR TITLE
fix: no excess files in manifest

### DIFF
--- a/packages/eslint-plugin-rebase/src/rebase.ts
+++ b/packages/eslint-plugin-rebase/src/rebase.ts
@@ -66,7 +66,7 @@ const rebase = ({ files, cliEngine }: RebaseOptions) => {
       break;
     }
 
-    if (!fileIgnores) {
+    if (!fileIgnores || !Object.keys(fileIgnores).length) {
       break;
     }
 


### PR DESCRIPTION
Closes #44. @binary64 noticed excess files in the manifest.

Before:

![Screen Shot 2021-07-11 at 5 10 05 PM](https://user-images.githubusercontent.com/615381/125211369-54fa4d00-e26b-11eb-973d-4320e139c603.png)

After:

![Screen Shot 2021-07-11 at 5 10 11 PM](https://user-images.githubusercontent.com/615381/125211359-4d3aa880-e26b-11eb-8633-bbe26b9d0f98.png)
